### PR TITLE
feat: update to version 2.0.0 with ESM support, dependency migration,…

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,7 @@
 # Ignore artifacts:
 lib
+lib-cjs
+scripts
 coverage
 *.lock
 .eslintrc.json

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ browser-token.json
 decoded-ws.json
 docs
 lib
+lib-cjs
 messages*.json
 node_modules
 output.csv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0 (2025-09-30)
+
+- chore: migrate dependencies to Baileys v7 rc.4 and require Node 20+
+- refactor: emit ESM artifacts and update all relative imports with file extensions
+- fix: replace deprecated `proto.*.fromObject` helpers with `.create` usage and local reaction/receipt merging utilities
+
 ## 1.0.1 (2025-05-17)
 
 

--- a/Example/example.ts
+++ b/Example/example.ts
@@ -299,7 +299,7 @@ const startSock = async() => {
 		}
 
 		// only if store is present
-		return proto.Message.fromObject({})
+		return proto.Message.create({})
 	}
 }
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ Note: This package requires `baileys` as a peer dependency. Make sure to install
 
 ## Requirements
 
-- Node.js >= 20
-- An ESM runtime (`type: "module"`). CommonJS consumers should load the library via `await import('@rodrigogs/baileys-store')`.
-- `baileys` ^7.0.0-rc.4
+
+- CommonJS support is available through the bundled `lib-cjs` build, so `const { makeInMemoryStore } = require('@rodrigogs/baileys-store')` also works.
 
 If you're migrating from an older release, replace any direct usage of `proto.*.fromObject` with `proto.*.create`.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ yarn add @rodrigogs/baileys-store baileys
 
 Note: This package requires `baileys` as a peer dependency. Make sure to install it alongside this package.
 
+## Requirements
+
+- Node.js >= 20
+- An ESM runtime (`type: "module"`). CommonJS consumers should load the library via `await import('@rodrigogs/baileys-store')`.
+- `baileys` ^7.0.0-rc.4
+
+If you're migrating from an older release, replace any direct usage of `proto.*.fromObject` with `proto.*.create`.
+
 # Usage
 
 This package provides different storage implementations for Baileys:

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -6,7 +6,14 @@ module.exports = {
 		'**/Tests/test.*.+(ts|tsx|js)',
 	],
 	'transform': {
-		'^.+\\.(ts|tsx)$': 'ts-jest'
+		'^.+\\.(ts|tsx)$': ['ts-jest', { useESM: true }]
+	},
+	'extensionsToTreatAsEsm': ['.ts'],
+	globals: {
+		'ts-jest': {
+			tsconfig: './tsconfig.json',
+			useESM: true
+		}
 	},
 	moduleNameMapper: {
 		'^axios$': require.resolve('axios'),

--- a/package.json
+++ b/package.json
@@ -13,29 +13,32 @@
   "license": "MIT",
   "author": "Rodrigo Gomes da Silva <rodrigo.smscom@gmail.com>",
   "type": "module",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "files": [
-    "lib/*"
+    "lib/*",
+    "lib-cjs/*"
   ],
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
-      "import": "./lib/index.js"
+      "import": "./lib/index.js",
+      "require": "./lib-cjs/index.js",
+      "default": "./lib/index.js"
     }
   },
   "scripts": {
     "build:all": "tsc && typedoc",
     "build:docs": "typedoc",
-    "build:tsc": "tsc",
+    "build:tsc": "tsc && tsc -p tsconfig.cjs.json && node ./scripts/prepare-cjs.mjs",
     "changelog:last": "conventional-changelog -p angular -r 2",
     "changelog:preview": "conventional-changelog -p angular -u",
     "changelog:update": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
     "example": "node --inspect -r ts-node/register Example/example.ts",
     "lint": "eslint src --ext .js,.ts",
-    "lint:fix": "yarn lint --fix",
-    "prepack": "tsc",
-    "prepare": "tsc",
+    "lint:fix": "npm run lint -- --fix",
+    "prepack": "npm run build:tsc",
+    "prepare": "npm run build:tsc",
     "release": "release-it",
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rodrigogs/baileys-store",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Baileys Store",
   "keywords": [
     "whatsapp",
@@ -12,11 +12,18 @@
   },
   "license": "MIT",
   "author": "Rodrigo Gomes da Silva <rodrigo.smscom@gmail.com>",
+  "type": "module",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
     "lib/*"
   ],
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.js"
+    }
+  },
   "scripts": {
     "build:all": "tsc && typedoc",
     "build:docs": "typedoc",
@@ -41,7 +48,7 @@
     "@types/jest": "^27.5.1",
     "@types/node": "^16.0.0",
     "@types/ws": "^8.0.0",
-    "baileys": "^6.7.17",
+    "baileys": "^7.0.0-rc.4",
     "conventional-changelog-cli": "^2.2.2",
     "eslint": "^8.0.0",
     "jest": "^27.0.6",
@@ -58,7 +65,7 @@
     "typescript": "^5.8.2"
   },
   "peerDependencies": {
-    "baileys": "^6.7.17"
+    "baileys": "^7.0.0-rc.4"
   },
   "peerDependenciesMeta": {
     "baileys": {

--- a/scripts/prepare-cjs.mjs
+++ b/scripts/prepare-cjs.mjs
@@ -1,0 +1,10 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const targetDir = resolve('lib-cjs')
+const packageJsonPath = resolve(targetDir, 'package.json')
+
+mkdirSync(targetDir, { recursive: true })
+
+const pkg = { type: 'commonjs' }
+writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`, { encoding: 'utf8' })

--- a/src/Store/index.ts
+++ b/src/Store/index.ts
@@ -1,3 +1,3 @@
-import makeCacheManagerAuthState from './make-cache-manager-store'
-import makeInMemoryStore from './make-in-memory-store'
+import makeCacheManagerAuthState from './make-cache-manager-store.js'
+import makeInMemoryStore from './make-in-memory-store.js'
 export { makeInMemoryStore, makeCacheManagerAuthState }

--- a/src/Store/make-cache-manager-store.ts
+++ b/src/Store/make-cache-manager-store.ts
@@ -1,7 +1,5 @@
-import { proto } from 'baileys'
-import { AuthenticationCreds } from 'baileys'
-import { BufferJSON, initAuthCreds } from 'baileys'
-import logger from 'baileys/lib/Utils/logger'
+import { type AuthenticationCreds, BufferJSON, initAuthCreds, proto } from 'baileys'
+import logger from 'baileys/lib/Utils/logger.js'
 import { caching, Store } from 'cache-manager'
 
 const makeCacheManagerAuthState = async(store: Store, sessionKey: string) => {
@@ -70,7 +68,7 @@ const makeCacheManagerAuthState = async(store: Store, sessionKey: string) => {
 							let value: proto.Message.AppStateSyncKeyData | AuthenticationCreds | null =
                                 await readData(`${type}-${id}`)
 							if(type === 'app-state-sync-key' && value) {
-								value = proto.Message.AppStateSyncKeyData.fromObject(value)
+								value = proto.Message.AppStateSyncKeyData.create(value as proto.Message.IAppStateSyncKeyData)
 							}
 
 							data[id] = value

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export * from './Store'
+export * from './Store/index.js'

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "lib-cjs",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2018",
-    "module": "CommonJS",
+  "target": "es2020",
+  "module": "NodeNext",
+  "moduleResolution": "NodeNext",
     "experimentalDecorators": true,
     "allowJs": false,
     "checkJs": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -296,6 +296,16 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@borewit/text-codec@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@borewit/text-codec/-/text-codec-0.1.1.tgz#7e7f27092473d5eabcffef693a849f2cc48431da"
+  integrity sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA==
+
+"@borewit/text-codec@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@borewit/text-codec/-/text-codec-0.2.0.tgz#1dbf3097b136b0dda56bce3ef53886c338ea3202"
+  integrity sha512-X999CKBxGwX8wW+4gFibsbiNdwqmdQEXmUejIWaIqdrHBgS5ARIOOeyiQbHjP9G58xVEPcuvP6VwwH3A0OFTOA==
+
 "@cacheable/node-cache@^1.4.0":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@cacheable/node-cache/-/node-cache-1.5.5.tgz#d1237ac3d2372a2b17843f9a0a065737bbd236cf"
@@ -1169,6 +1179,15 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
+"@tokenizer/inflate@^0.2.7":
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/@tokenizer/inflate/-/inflate-0.2.7.tgz#32dd9dfc9abe457c89b3d9b760fc0690c85a103b"
+  integrity sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==
+  dependencies:
+    debug "^4.4.0"
+    fflate "^0.8.2"
+    token-types "^6.0.0"
+
 "@tokenizer/token@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"
@@ -1777,19 +1796,18 @@ babel-preset-jest@^27.5.1:
     babel-plugin-jest-hoist "^27.5.1"
     babel-preset-current-node-syntax "^1.0.0"
 
-baileys@^6.7.17:
-  version "6.7.17"
-  resolved "https://registry.yarnpkg.com/baileys/-/baileys-6.7.17.tgz#3a20f9ce570a1f5373d6346faba7209d2856cfe0"
-  integrity sha512-p/swKm/7ecHcDhKHzAZzxlaGEkjYqxUwAaNzDjhhmCuf7hmR2rIbRzTGIMKJRbFTl/QKnkRLXAVNjYZmXYeeAg==
+baileys@^7.0.0-rc.4:
+  version "7.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/baileys/-/baileys-7.0.0-rc.4.tgz#b9bac6bdb7949faf694740a6cfed18ef565fb455"
+  integrity sha512-mmXWTRYg3lcs20s/qHYZ5PQP6/qwID8Kgft7m2nMaHdAF13GbRSq59IcZolcbQSJ9UIrw26HPCFA2xYdBHUcqA==
   dependencies:
     "@cacheable/node-cache" "^1.4.0"
     "@hapi/boom" "^9.1.3"
-    "@whiskeysockets/eslint-config" "github:whiskeysockets/eslint-config"
     async-mutex "^0.5.0"
     axios "^1.6.0"
-    libsignal "github:WhiskeySockets/libsignal-node"
-    lodash "^4.17.21"
-    music-metadata "^7.12.3"
+    libsignal "git+https://github.com/whiskeysockets/libsignal-node"
+    lru-cache "^11.1.0"
+    music-metadata "^11.7.0"
     pino "^9.6"
     protobufjs "^7.2.4"
     ws "^8.13.0"
@@ -2606,6 +2624,13 @@ debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   dependencies:
     ms "^2.1.3"
 
+debug@^4.4.0, debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 decamelize-keys@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.1.tgz#04a2d523b2f18d80d0158a43b895d56dff8d19d8"
@@ -3308,6 +3333,11 @@ fetch-blob@^3.1.2, fetch-blob@^3.1.4:
     node-domexception "^1.0.0"
     web-streams-polyfill "^3.0.3"
 
+fflate@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.8.2.tgz#fc8631f5347812ad6028bbe4a2308b2792aa1dea"
+  integrity sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==
+
 figures@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-5.0.0.tgz#126cd055052dea699f8a54e8c9450e6ecfc44d5f"
@@ -3331,6 +3361,16 @@ file-type@^16.5.4:
     readable-web-to-node-stream "^3.0.0"
     strtok3 "^6.2.4"
     token-types "^4.1.1"
+
+file-type@^21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-21.0.0.tgz#b6c5990064bc4b704f8e5c9b6010c59064d268bc"
+  integrity sha512-ek5xNX2YBYlXhiUXui3D/BXa3LdqPmoLJ7rqEx2bKJ7EAUEfmXgW0Das7Dc6Nr9MvqaOnIqiPV0mZk/r/UpNAg==
+  dependencies:
+    "@tokenizer/inflate" "^0.2.7"
+    strtok3 "^10.2.2"
+    token-types "^6.0.0"
+    uint8array-extras "^1.4.0"
 
 fill-range@^7.1.1:
   version "7.1.1"
@@ -4989,9 +5029,9 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-"libsignal@github:WhiskeySockets/libsignal-node":
+"libsignal@git+https://github.com/whiskeysockets/libsignal-node.git":
   version "2.0.1"
-  resolved "https://codeload.github.com/WhiskeySockets/libsignal-node/tar.gz/d13b6622a208d3037a98b6f447bbde70261c39a9"
+  resolved "git+https://github.com/whiskeysockets/libsignal-node.git#e81ecfc32eb74951d789ab37f7e341ab66d5fff1"
   dependencies:
     curve25519-js "^0.0.4"
     protobufjs "6.8.8"
@@ -5149,6 +5189,11 @@ lru-cache@^10.2.2:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
+lru-cache@^11.1.0:
+  version "11.2.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.2.2.tgz#40fd37edffcfae4b2940379c0722dc6eeaa75f24"
+  integrity sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -5369,18 +5414,20 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-music-metadata@^7.12.3:
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/music-metadata/-/music-metadata-7.14.0.tgz#74e3e5fc8e09b86d1a3e791fb5ce9ccdc4347ad9"
-  integrity sha512-xrm3w7SV0Wk+OythZcSbaI8mcr/KHd0knJieu8bVpaPfMv/Agz5EooCAPz3OR5hbYMiUG6dgAPKZKnMzV+3amA==
+music-metadata@^11.7.0:
+  version "11.9.0"
+  resolved "https://registry.yarnpkg.com/music-metadata/-/music-metadata-11.9.0.tgz#74108323106d5fb93e969a96a9136f8bc5b8d209"
+  integrity sha512-J7VqD8FY6KRcm75Fzj86FPsckiD/EdvO5OS3P+JiMf/2krP3TcAseZYfkic6eFeJ0iBhhzcdxgfu8hLW95aXXw==
   dependencies:
+    "@borewit/text-codec" "^0.2.0"
     "@tokenizer/token" "^0.3.0"
     content-type "^1.0.5"
-    debug "^4.3.4"
-    file-type "^16.5.4"
+    debug "^4.4.3"
+    file-type "^21.0.0"
     media-typer "^1.1.0"
-    strtok3 "^6.3.0"
-    token-types "^4.2.1"
+    strtok3 "^10.3.4"
+    token-types "^6.1.1"
+    uint8array-extras "^1.5.0"
 
 mute-stream@1.0.0:
   version "1.0.0"
@@ -6908,7 +6955,14 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
-strtok3@^6.2.4, strtok3@^6.3.0:
+strtok3@^10.2.2, strtok3@^10.3.4:
+  version "10.3.4"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-10.3.4.tgz#793ebd0d59df276a085586134b73a406e60be9c1"
+  integrity sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==
+  dependencies:
+    "@tokenizer/token" "^0.3.0"
+
+strtok3@^6.2.4:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.3.0.tgz#358b80ffe6d5d5620e19a073aa78ce947a90f9a0"
   integrity sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==
@@ -7114,11 +7168,20 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-token-types@^4.1.1, token-types@^4.2.1:
+token-types@^4.1.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/token-types/-/token-types-4.2.1.tgz#0f897f03665846982806e138977dbe72d44df753"
   integrity sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==
   dependencies:
+    "@tokenizer/token" "^0.3.0"
+    ieee754 "^1.2.1"
+
+token-types@^6.0.0, token-types@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-6.1.1.tgz#85bd0ada82939b9178ecd5285881a538c4c00fdd"
+  integrity sha512-kh9LVIWH5CnL63Ipf0jhlBIy0UsrMj/NJDfpsy1SqOXlLKEVyXXYrnFxFT1yOOYVGBSApeVnjPw/sBz5BfEjAQ==
+  dependencies:
+    "@borewit/text-codec" "^0.1.0"
     "@tokenizer/token" "^0.3.0"
     ieee754 "^1.2.1"
 
@@ -7334,6 +7397,11 @@ uglify-js@^3.1.4:
   version "3.19.3"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.19.3.tgz#82315e9bbc6f2b25888858acd1fff8441035b77f"
   integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
+
+uint8array-extras@^1.4.0, uint8array-extras@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/uint8array-extras/-/uint8array-extras-1.5.0.tgz#10d2a85213de3ada304fea1c454f635c73839e86"
+  integrity sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This pull request introduces a major version update (2.0.0) with significant changes to support Baileys v7 (release candidate 4) and Node.js 20+, migrates the codebase to ESM-only modules, and replaces deprecated proto helpers with updated usage and local utilities. It also updates all relative imports to include file extensions and refactors test and build configurations for ESM compatibility.

**Dependency and Runtime Upgrades:**

* Migrated dependencies to `baileys` v7.0.0-rc.4 and set Node.js 20+ as the minimum required version. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L44-R51) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L61-R68) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R6) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19-R26)
* The package now requires an ESM runtime (`type: "module"` in `package.json`), and CommonJS consumers must use dynamic import. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R15-R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19-R26)

**Codebase Refactoring for ESM:**

* All internal relative imports now include file extensions (e.g., `.js`), and the `exports` field is set in `package.json` for ESM compatibility. [[1]](diffhunk://#diff-676fcd31733898b2bef4e3e71728a31a8ce48a5d3bd8f6b32f773957b0cd49b7L1-R2) [[2]](diffhunk://#diff-8eeb3c3f3f336154452f91a57a93875025bd6e19ebd178f4235c671ab16ac542L1-R29) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L1-R1) [[4]](diffhunk://#diff-d5218c9c6c4c6ccd6745e20f24a6bbe0a6bc62861a1e599934747c8625033c14L1-R2) [[5]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R15-R26)

**Deprecation Handling and Utility Replacement:**

* Replaced deprecated `proto.*.fromObject` helpers with `proto.*.create` and implemented local utilities for merging reactions and receipts (`mergeUserReceipt`, `mergeMessageReaction`). [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R6) [[2]](diffhunk://#diff-d5218c9c6c4c6ccd6745e20f24a6bbe0a6bc62861a1e599934747c8625033c14L73-R71) [[3]](diffhunk://#diff-8eeb3c3f3f336154452f91a57a93875025bd6e19ebd178f4235c671ab16ac542R52-R103) [[4]](diffhunk://#diff-8eeb3c3f3f336154452f91a57a93875025bd6e19ebd178f4235c671ab16ac542L313-R362) [[5]](diffhunk://#diff-8eeb3c3f3f336154452f91a57a93875025bd6e19ebd178f4235c671ab16ac542L323-R372) [[6]](diffhunk://#diff-8eeb3c3f3f336154452f91a57a93875025bd6e19ebd178f4235c671ab16ac542L345-R394) [[7]](diffhunk://#diff-d481c6e45abbf8b680afa2e51ea603e4eb79056c982c22e2c6563df334a20e87L302-R302)

**Testing and Build Configuration Updates:**

* Updated `jest.config.js` to `jest.config.cjs`, enabling ESM support for tests and specifying `.ts` as an ESM extension.

**Documentation:**

* Updated `README.md` and `CHANGELOG.md` to reflect new requirements, migration notes, and breaking changes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19-R26) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R6) F962d673L1)

These changes collectively modernize the package, ensure compatibility with the latest Baileys release, and future-proof the codebase for ESM and Node.js 20+ environments.